### PR TITLE
Replace custom editor with CodeMirror

### DIFF
--- a/tidyparse-web/src/jsMain/kotlin/JSTidyPyEditor.kt
+++ b/tidyparse-web/src/jsMain/kotlin/JSTidyPyEditor.kt
@@ -10,7 +10,7 @@ import kotlin.time.TimeSource
 
 
 @ExperimentalUnsignedTypes
-class JSTidyPyEditor(override val editor: HTMLTextAreaElement, override val output: Node) : JSTidyEditor(editor, output) {
+class JSTidyPyEditor(override val editor: dynamic, override val output: Node) : JSTidyEditor(editor, output) {
   val ngrams: MutableMap<List<String>, Double> = mutableMapOf()
 
   val order: Int by lazy { ngrams.keys.firstOrNull()!!.size }
@@ -33,7 +33,6 @@ class JSTidyPyEditor(override val editor: HTMLTextAreaElement, override val outp
       preparseParseableLines(decCFG, readEditorText()) {
         PyCodeSnippet(it).lexedTokens().replace("|", "OR") in decCFG.language
       }
-      if (currentHash == hashIter) decorator.fullDecorate(decCFG)
     }
 
     continuation { decorate() }

--- a/tidyparse-web/src/jsMain/resources/index.html
+++ b/tidyparse-web/src/jsMain/resources/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <link href='https://fonts.googleapis.com/css?family=JetBrains Mono' rel='stylesheet'>
   <link rel="stylesheet" type="text/css" href="index.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js"></script>
   <title>Tidyparse</title>
   <link rel="icon" href="/pluginIcon.svg" type="image/svg+xml">
 </head>
@@ -11,7 +13,7 @@
 <!-- Now render the pluginIcon.svg next to the header: -->
 <h1><img style="display: inline;" src="/pluginIcon.svg" width="26">&nbsp;&nbsp;Tidyparse Browser Demonstration</h1>
 <div id="content">
-<textarea id="tidyparse-input" class="ldt" spellcheck="false"></textarea>
+<textarea id="tidyparse-input" spellcheck="false"></textarea>
 <div id="tidyparse-output" class="panel">
    Usage Tips:
 

--- a/tidyparse-web/src/jsMain/resources/python.html
+++ b/tidyparse-web/src/jsMain/resources/python.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <link href='https://fonts.googleapis.com/css?family=JetBrains Mono' rel='stylesheet'>
     <link rel="stylesheet" type="text/css" href="index.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js"></script>
     <title>TidyPython</title>
     <link rel="icon" href="/pluginIcon.svg" type="image/svg+xml">
 </head>
@@ -11,7 +13,7 @@
 <!-- Now render the pluginIcon.svg next to the header: -->
 <h1><img style="display: inline;" src="/pluginIcon.svg" width="26">&nbsp;&nbsp;TidyPython Browser Demonstration</h1>
 <div id="content">
-    <textarea id="tidyparse-input" class="ldt" spellcheck="false">
+    <textarea id="tidyparse-input" spellcheck="false">
 x = 1 -
 x = 1 + 1
 


### PR DESCRIPTION
## Summary
- integrate CodeMirror as the editor for the web demo
- update Kotlin client to use CodeMirror API
- adjust editor classes for dynamic access to CodeMirror
- fix build by checking out galoisenne submodule

## Testing
- `./gradlew build` *(fails: Could not resolve IntelliJ dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f7091ee508326bc83886ec49e6d52